### PR TITLE
Tune positions of some vision torches

### DIFF
--- a/planets/SolarSystem/dream_world.json
+++ b/planets/SolarSystem/dream_world.json
@@ -320,7 +320,7 @@
             },
             "rotation": {
               "x": 354.4057,
-              "y": 47.4029,
+              "y": 97.4029,
               "z": 356.12
             },
             "path": "Sector_DreamWorld/Sector_DreamZone_4/Interactibles_DreamZone_4_Upper/Prefab_IP_VisionTorchProjector/Effects_IP_SIM_VisionTorch",

--- a/planets/SolarSystem/dream_world.json
+++ b/planets/SolarSystem/dream_world.json
@@ -331,13 +331,13 @@
           {
             "scale": 1,
             "position": {
-              "x": -27.8238,
-              "y": 33.9664,
-              "z": -191.37
+              "x": -29.926,
+              "y": 33.7664,
+              "z": -179.7224
             },
             "rotation": {
               "x": 354.8344,
-              "y": 317.5115,
+              "y": 180,
               "z": 0
             },
             "path": "Sector_DreamWorld/Sector_DreamZone_4/Interactibles_DreamZone_4_Upper/Prefab_IP_VisionTorchProjector/Effects_IP_SIM_VisionTorch",
@@ -466,13 +466,13 @@
               }
             ],
             "position": {
-              "x": -27.8238,
-              "y": 33.9664,
-              "z": -191.37
+              "x": -29.926,
+              "y": 33.7664,
+              "z": -179.7224
             },
             "rotation": {
               "x": 354.8344,
-              "y": 317.5115,
+              "y": 180,
               "z": 0
             },
             "reveals": [ "IP_ENTRANCE_LAKE" ],


### PR DESCRIPTION
**This is a proposal, please consider it if you like it.**

## Tune the position of the vision torch in the tower
I think the vision torch in the tower can be missed out among some people. like below:
![スクリーンショット (3086)](https://github.com/artificialparanoia/Divergence/assets/17728957/701f59ef-0b86-437a-98de-36fbc8dca8a9)
![スクリーンショット (3087)](https://github.com/artificialparanoia/Divergence/assets/17728957/562ad077-92c5-45f2-968b-76e96cd7e13d)
![スクリーンショット (3088)](https://github.com/artificialparanoia/Divergence/assets/17728957/4945ade8-847c-4091-b1be-c26da303572a)
![スクリーンショット (3089)](https://github.com/artificialparanoia/Divergence/assets/17728957/9c285fb6-4fd6-4fbd-83d9-6cbc51e395b3)
![スクリーンショット (3090)](https://github.com/artificialparanoia/Divergence/assets/17728957/4019cba5-e804-4e24-9901-9e9e1e70bca8)

... oh, this hatchling cannot notice the vision torch, sadly.

So, I propose that the position should be in the center of the candles.
This pull request changes it as below:
![スクリーンショット (3098)](https://github.com/artificialparanoia/Divergence/assets/17728957/61cafdaf-14cb-4787-be54-adf7299c4103)
![スクリーンショット (3099)](https://github.com/artificialparanoia/Divergence/assets/17728957/098c8b41-7337-41c5-924c-34d0202a933a)

## Fix the rotation of the vision torch near the Mainframe
The simplified version of the vision torch near the Mainframe has wrong rotations. It is not consistent with the not simplified version of this vision torch:
![スクリーンショット (3110)](https://github.com/artificialparanoia/Divergence/assets/17728957/0f036b23-b65b-490b-88f3-f3552ee23b35)
![スクリーンショット (3093)](https://github.com/artificialparanoia/Divergence/assets/17728957/f12e64d8-053a-403b-8bfb-5d165b3b61d0)

So, this pull request fixes it like this:
![スクリーンショット (3106)](https://github.com/artificialparanoia/Divergence/assets/17728957/dc583af9-a193-407f-b684-7b3a007b4ac1)

Thanks.